### PR TITLE
fix for updated RNN API

### DIFF
--- a/BilinearSamplerBHWD.lua
+++ b/BilinearSamplerBHWD.lua
@@ -71,7 +71,7 @@ function BilinearSamplerBHWD:updateOutput(input)
 
    self.output:resize(inputImages:size(1), grids:size(2), grids:size(3), inputImages:size(4))	
 
-	inputImages.nn.BilinearSamplerBHWD_updateOutput(self, inputImages, grids)
+	inputImages.nn.BilinearSamplerBHWD_updateOutput(self, inputImages, grids, self.output)
 
    if _inputImages:nDimension()==3 then
       self.output=self.output:select(1,1)

--- a/main-demo-ConvLSTM.lua
+++ b/main-demo-ConvLSTM.lua
@@ -115,7 +115,7 @@ local function main()
         err = 0
       end
       if opt.save and math.fmod(t , opt.saveInterval) == 0 then
-        model.cleanState()      
+        model:clearState()      
         torch.save(opt.dir .. '/model_' .. t .. '.bin', model)
         config = {eta = eta, epsilon = epsilon, alpha = alpha, iter = iter, epoch = epoch}
         torch.save(opt.dir .. '/config_' .. t .. '.bin', config)


### PR DESCRIPTION
Hi @viorik 
recent rnn API changes resulted in current code has signature errors

```
$ th main-mnist.lua
8000 20 64 64
Loaded 8000 images  
==> training model  
Number of parameters 915466 
Number of grads 915466  
/home/user/torch/install/bin/luajit: /home/user/torch/install/share/lua/5.1/nn/Container.lua:67: 
In 3 module of nn.Sequential:
./BilinearSamplerBHWD.lua:74: bad argument #4 to 'BilinearSamplerBHWD_updateOutput' (torch.CudaTensor expected, got string)
stack traceback:
    [C]: in function 'BilinearSamplerBHWD_updateOutput'
    ./BilinearSamplerBHWD.lua:74: in function <./BilinearSamplerBHWD.lua:55>
    [C]: in function 'xpcall'
    /home/user/torch/install/share/lua/5.1/nn/Container.lua:63: in function 'rethrowErrors'
    /home/user/torch/install/share/lua/5.1/nn/Sequential.lua:44: in function 'updateOutput'
    main-mnist.lua:80: in function 'opfunc'
    /home/user/torch/install/share/lua/5.1/optim/rmsprop.lua:34: in function 'rmsprop'
    main-mnist.lua:105: in function 'main'
    main-mnist.lua:161: in main chunk
    [C]: in function 'dofile'
    ...user/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:145: in main chunk
    [C]: at 0x00406670
```

Proposed fix, is same that can be found for other rnn related modules for example:
[https://github.com/jcjohnson/densecap/issues/6](url)
